### PR TITLE
fix(weapon): 修正武器类型、伤害与换弹数据

### DIFF
--- a/data/weapons/Bully.mdx
+++ b/data/weapons/Bully.mdx
@@ -22,6 +22,7 @@ magazine: 32
 total_ammo: 320
 accuracy: 75
 stability: 78
+reload_time: 2.3
 scope: 低倍镜
 attenuation_begin: 18
 attenuation_end: 40
@@ -49,3 +50,10 @@ skill_cooldown: 20
     开镜时获得临时护盾，<Yellow>5秒</Yellow>内未受到伤害时，临时护盾开始回复。
   </PassiveSkill>
 </WeaponSkill>
+
+
+| 伤害类型 | 单次伤害（500×系数） | 破韧伤害 | 暴击 | 弱点 | 弱点倍率 |
+| - | - | - | - | - | - |
+| 普通射击 | 78.5 | 1.9 | 可暴击 | 可弱点 | 1.3x |
+| 无人机射击 | 40 | - | 否 | 否 | - |
+| 无人机自爆 | 250 | - | 否 | 否 | - |

--- a/data/weapons/幽冥毒皇.mdx
+++ b/data/weapons/幽冥毒皇.mdx
@@ -25,7 +25,7 @@ magazine: 100
 total_ammo: 1000
 accuracy: 80
 stability: 50
-reload_time: '2.8'
+reload_time: 2.8
 range: ''
 explosion_range: ''
 attenuation_begin: 49

--- a/data/weapons/心有凌兮.mdx
+++ b/data/weapons/心有凌兮.mdx
@@ -1,6 +1,6 @@
 ---
 title: 心有凌兮
-use_type: 主武器
+use_type: 副武器
 weapon_type: 单发榴弹
 element: 火焰
 rarity: 传说
@@ -22,7 +22,7 @@ magazine: 1
 total_ammo: 10
 accuracy: 67
 stability: 32
-reload_time: 2
+reload_time: 1.9
 scope: 低倍镜
 attenuation_begin: 0
 attenuation_end: 0

--- a/data/weapons/春雷震.mdx
+++ b/data/weapons/春雷震.mdx
@@ -1,7 +1,7 @@
 ---
 title: 春雷震
 use_type: 主武器
-weapon_type: 单发榴弹
+weapon_type: 连发榴弹
 element: 火焰
 rarity: 传说
 tags: null

--- a/data/weapons/浪里白条.mdx
+++ b/data/weapons/浪里白条.mdx
@@ -20,11 +20,11 @@ toughness_type: 冲击
 enable_critical: true
 weekness_multiplier: 1.5
 fire_interval: 0.5
-magazine: 30
-total_ammo: 300
-accuracy: 70
-stability: 60
-reload_time: 3.3 
+magazine: 8
+total_ammo: 40
+accuracy: 77
+stability: 80
+reload_time: 3.3
 range: -1
 explosion_range: -1
 attenuation_begin: 60

--- a/data/weapons/炼狱蝎王.mdx
+++ b/data/weapons/炼狱蝎王.mdx
@@ -5,11 +5,11 @@ weapon_type: 冲锋枪
 element: 火焰
 rarity: 传说
 tags: 元素异常
-scope: 低倍镜
+scope: 不可开镜
 weapon_type_id: 5
 prototype_id: '20005000034'
 asc_type_id: 339
-active_skill_id: 5102701
+active_skill_id: 5104101
 damage:
   base: 0.07
   impulse: 0.8
@@ -21,7 +21,7 @@ enable_critical: true
 weekness_multiplier: 1.3
 fire_interval: 0.045
 magazine: 100
-total_ammo: 300
+total_ammo: 1700
 accuracy: 80
 stability: 69
 reload_time: 1.9

--- a/data/weapons/疾影逐风.mdx
+++ b/data/weapons/疾影逐风.mdx
@@ -9,7 +9,7 @@ prototype_id: '20003000031'
 asc_type_id: 381
 active_skill_id: 5103301
 damage:
-  base: 0.09
+  base: 0.083
   impulse: 0.6
   toughness: 0.6
   flesh: 0.5
@@ -18,11 +18,11 @@ toughness_type: 冲击
 enable_critical: true
 weekness_multiplier: 1.2
 fire_interval: 0.4
-magazine: 12
-total_ammo: 108
+magazine: 18
+total_ammo: 180
 accuracy: 59
-stability: 64
-reload_time: 2
+stability: 63
+reload_time: 1.8
 scope: 不可开镜
 attenuation_begin: 10
 attenuation_end: 20

--- a/data/weapons/胜利誓约.mdx
+++ b/data/weapons/胜利誓约.mdx
@@ -17,8 +17,8 @@ toughness_type: 冲击
 enable_critical: true
 weekness_multiplier: 1.3
 fire_interval: 0.12
-magazine: 38
-total_ammo: 646
+magazine: 50
+total_ammo: 850
 accuracy: 74
 stability: 68
 reload_time: 1.6

--- a/data/weapons/黑金仲裁者.mdx
+++ b/data/weapons/黑金仲裁者.mdx
@@ -22,6 +22,7 @@ magazine: 24
 total_ammo: 168
 accuracy: 75
 stability: 55
+reload_time: 2.3
 scope: 低倍镜
 attenuation_begin: 18
 attenuation_end: 40


### PR DESCRIPTION
## 变更内容
- 修正 Bully 的换弹配置，补充普通射击、无人机射击和无人机自爆的伤害数据表
- 修正幽冥毒皇的换弹字段格式
- 修正心有凌兮的武器分类及换弹配置
- 修正春雷震的武器分类
- 修正浪里白条的弹匣、备弹、精准度和稳定性
- 修正炼狱蝎王的瞄准镜、主动技能及备弹配置
- 修正疾影逐风的伤害系数、弹匣、备弹、稳定性和换弹配置
- 修正胜利誓约的弹匣与备弹配置
- 补充黑金仲裁者的换弹配置
- 未包含临时文件、日志和构建产物

## 关联 Issue

Closes #16

答应我用rebase好嘛，merge好丑哦（